### PR TITLE
feat: Make it possible to have coffee config files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+require('coffee-script/register')
 const path = require('path')
 const assert = require('assert')
 const pointer = require('jsonpointer')

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@semantic-release/condition-travis": "^4.1.4",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "coffee-script": "^1.10.0",
     "coveralls": "^2.11.15",
     "greenkeeper-postpublish": "^1.0.1",
     "semantic-release": "^4.3.5",

--- a/test/fixtures/environments/staging-coffee.coffee
+++ b/test/fixtures/environments/staging-coffee.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  environments_staging: true
+  overwritten: false
+  merge: environments: test: true

--- a/test/unit/conf_tests.js
+++ b/test/unit/conf_tests.js
@@ -31,6 +31,11 @@ describe('The Conf', () => {
       return expect(config.get('environments_staging')).to.be.true
     })
 
+    it('loads coffee files', () => {
+      const config = Conf.loadEnvironment(pathToFixtures, 'staging-coffee')
+      return expect(config.get('environments_staging')).to.be.true
+    })
+
     it('throws MODULE_NOT_FOUND errors if required', () => {
       const loadWithInvalidRequire = () => Conf.loadEnvironment(pathToFixtures, 'with_invalid_require')
       return expect(loadWithInvalidRequire).to.throw(/Cannot find module/)


### PR DESCRIPTION
I ran into issues in the bluewin downstream, this package couldn't load coffeescript config:

```
/Volumes/repositories/livingdocs/bluewin-server
❯ nr reset

> @livingdocs/bluewin-server@0.0.0-placeholder reset /Volumes/repositories/livingdocs/bluewin-server
> node bin/feed-import/commands/reset.js

Error: Cannot find module '/Volumes/repositories/livingdocs/bluewin-server/conf/environments/all'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at loadFile (/Volumes/repositories/livingdocs/bluewin-server/node_modules/@livingdocs/conf/index.js:59:12)
    at Function.loadEnvironment (/Volumes/repositories/livingdocs/bluewin-server/node_modules/@livingdocs/conf/index.js:18:16)
    at Object.<anonymous> (/Volumes/repositories/livingdocs/bluewin-server/conf/index.js:5:28)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @livingdocs/bluewin-server@0.0.0-placeholder reset: `node bin/feed-import/commands/reset.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @livingdocs/bluewin-server@0.0.0-placeholder reset script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```