### PR TITLE
Do not catch any errors that happen within the config file itself

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,14 @@ steps:
   image: node:8-alpine
   commands: ["npm run test -s"]
 
+- name: test-node-10
+  image: node:10-alpine
+  commands: ["npm run test -s"]
+
+- name: test-node-12
+  image: node:12-alpine
+  commands: ["npm run test -s"]
+
 - name: publish
   image: livingdocs/semantic-release:v1.0.0
   environment:
@@ -36,6 +44,6 @@ trigger:
   event: [push]
 ---
 kind: signature
-hmac: ac531211552345c14a7f9acef077dba96d0f9602d8c298a0f1f779797cf0237e
+hmac: 4c62a9554ee87f9598c6e662491d737c89f028e5fd457202edd2561000957b2c
 
 ...

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ module.exports = class Conf {
     assert(path.isAbsolute(configDir), 'configDir must be an absolute path')
     const conf = new Conf()
 
-    conf.merge(loadFile(configDir, 'environments/', 'all', {required: true}))
-    conf.merge(loadFile(configDir, 'environments', env, {required: true}))
-    conf.merge(loadFile(configDir, 'secrets', env, {required: false}))
+    conf.merge(loadFile([configDir, 'environments/all'], {required: true}))
+    conf.merge(loadFile([configDir, 'environments', env], {required: true}))
+    conf.merge(loadFile([configDir, 'secrets', env], {required: false}))
     conf.merge(getEnvVariables())
     conf.set('environment', env)
     return conf
@@ -47,10 +47,7 @@ module.exports = class Conf {
   }
 }
 
-function loadFile () {
-  const parts = _.take(arguments, arguments.length - 1)
-  const opts = arguments[arguments.length - 1]
-  const required = opts.required
+function loadFile (parts, opts) {
   const p = path.join.apply(path, parts)
 
   try {

--- a/index.js
+++ b/index.js
@@ -56,9 +56,10 @@ function loadFile () {
   try {
     return require(p)
   } catch (e) {
-    const isLoadError = e.code === 'MODULE_NOT_FOUND' && e.message === `Cannot find module '${p}'`
-    if (!isLoadError) throw e
-    if (required) throw e
+    if (!(e.code === 'MODULE_NOT_FOUND' && e.message.startsWith(`Cannot find module '${p}'`))) {
+      throw e
+    }
+    if (opts.required) throw e
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -55,10 +55,10 @@ function loadFile () {
 
   try {
     return require(p)
-  } catch (err) {
-    const requireError = err.code === 'MODULE_NOT_FOUND'
-    if (!requireError) throw err
-    if (required) throw err
+  } catch (e) {
+    const isLoadError = e.code === 'MODULE_NOT_FOUND' && e.message === `Cannot find module '${p}'`
+    if (!isLoadError) throw e
+    if (required) throw e
   }
 }
 

--- a/test/fixtures/secrets/with_invalid_require_in_secret.js
+++ b/test/fixtures/secrets/with_invalid_require_in_secret.js
@@ -1,0 +1,3 @@
+module.exports = {
+  invalidSecret: require('./hello-nonexistent-module')
+}

--- a/test/unit/conf_tests.js
+++ b/test/unit/conf_tests.js
@@ -34,7 +34,8 @@ describe('The Conf', () => {
     it('throws MODULE_NOT_FOUND errors if required', () => {
       const loadWithInvalidRequire = () =>
         Conf.loadEnvironment(pathToFixtures, 'with_invalid_require')
-      expect(loadWithInvalidRequire).to.throw(/Cannot find module/)
+      expect(loadWithInvalidRequire).to.throw('Cannot find module')
+        .with.property('code', 'MODULE_NOT_FOUND')
     })
 
     it('catches MODULE_NOT_FOUND errors if optional', () => {
@@ -51,6 +52,13 @@ describe('The Conf', () => {
       const loadWithInvalidRequire = () =>
         Conf.loadEnvironment(pathToFixtures, 'with_invalid_secret')
       expect(loadWithInvalidRequire).to.throw('foobar is not defined')
+    })
+
+    it('swallows the MODULE_NOT_FOUND error only for the direct require', () => {
+      const loadWithInvalidRequire = () =>
+        Conf.loadEnvironment(pathToFixtures, 'with_invalid_require_in_secret')
+      expect(loadWithInvalidRequire).to.throw('Cannot find module')
+        .with.property('code', 'MODULE_NOT_FOUND')
     })
 
     describe('environment values:', () => {


### PR DESCRIPTION
I've run into an issue where my secret file wasn't loaded because it declared a require for a module that wasn't present.

With the change in here, the config loader only catches `require` errors that happen because of a faulty lookup. All the errors that are thrown within the config file, will result in an error.

```js
// secret.js that was completely ignored because of a module, that wasn't present in the project
// The error just got swallowed instead thrown
module.exports = {
  example: require('non-existent-module')
}